### PR TITLE
Add missing methods for HMActionSet and HMEventTrigger

### DIFF
--- a/Sources/HMActionSet+Promise.swift
+++ b/Sources/HMActionSet+Promise.swift
@@ -14,6 +14,13 @@ extension HMActionSet {
             self.addAction(action, completionHandler: seal.resolve)
         }
     }
+    
+    @available(iOS 8.0, *)
+    public func removeAction(_ action: HMAction) -> Promise<Void> {
+        return Promise { seal in
+            self.removeAction(action, completionHandler: seal.resolve)
+        }
+    }
 
     @available(iOS 8.0, *)
     public func updateName(_ name: String) -> Promise<Void> {

--- a/Sources/HMEventTrigger+Promise.swift
+++ b/Sources/HMEventTrigger+Promise.swift
@@ -15,6 +15,34 @@ extension HMEventTrigger {
             self.updateExecuteOnce(executeOnce, completionHandler: seal.resolve)
         }
     }
+    
+    @available(iOS 11.0, *)
+    public func updateEvents(_ events: [HMEvent]) -> Promise<Void> {
+        return Promise { seal in
+            self.updateEvents(events, completionHandler: seal.resolve)
+        }
+    }
+    
+    @available(iOS 11.0, *)
+    public func updateEndEvents(_ events: [HMEvent]) -> Promise<Void> {
+        return Promise { seal in
+            self.updateEndEvents(events, completionHandler: seal.resolve)
+        }
+    }
+    
+    @available(iOS 9.0, *)
+    public func updatePredicate(_ predicate: NSPredicate?) -> Promise<Void> {
+        return Promise { seal in
+            self.updatePredicate(predicate, completionHandler: seal.resolve)
+        }
+    }
+    
+    @available(iOS 11.0, *)
+    public func updateRecurrences(_ recurrences: [DateComponents]?) -> Promise<Void> {
+        return Promise { seal in
+            self.updateRecurrences(recurrences, completionHandler: seal.resolve)
+        }
+    }
 
 }
 


### PR DESCRIPTION
This adds all missing methods for HMActionSet and HMEventTrigger.

I use your HomeKit extension for PromiseKit in one of my projects and it's great, thank you for it! As I participate in the hacktoberfest: Could you add the `hacktoberfest-accepted` label to this PR, if you find it useful? Would help me a lot!